### PR TITLE
Add Contact model (document) and associated models, etc. to codebase. 

### DIFF
--- a/star_tides/api/blueprint.py
+++ b/star_tides/api/blueprint.py
@@ -4,6 +4,7 @@ This module contains the main blueprint for star_tides.
 
 '''
 
+from datetime import datetime
 from flask import Blueprint
 from star_tides.api.decorators.login_required import login_required
 bp = Blueprint('bp', __name__)
@@ -13,3 +14,7 @@ bp = Blueprint('bp', __name__)
 @login_required
 def index():
     return "It's an app yo"
+
+@bp.route('/test_route/no_auth')
+def index_no_auth():
+    return "It's an app yo [no auth] %s" % datetime.now()

--- a/star_tides/api/blueprint.py
+++ b/star_tides/api/blueprint.py
@@ -17,4 +17,4 @@ def index():
 
 @bp.route('/test_route/no_auth')
 def index_no_auth():
-    return "It's an app yo [no auth] %s" % datetime.now()
+    return f"It's an app yo [no auth] {datetime.now()}"

--- a/star_tides/services/databases/mongo/models/availability.py
+++ b/star_tides/services/databases/mongo/models/availability.py
@@ -1,0 +1,11 @@
+'''Enums and utilities related to Contact Availability at the database-level.'''
+
+from enum import Enum, auto
+
+class Availability(Enum):
+    '''Availability is an enum describing a Contact's availability.'''
+
+    UNSPECIFIED = auto()
+    UNAVAILABLE = auto()
+    AVAILABLE = auto()
+    

--- a/star_tides/services/databases/mongo/models/availability.py
+++ b/star_tides/services/databases/mongo/models/availability.py
@@ -1,4 +1,8 @@
-'''Enums and utilities related to Contact Availability at the database-level.'''
+'''
+star_tides.services.databases.mongo.models.availability
+
+Enums and utilities related to Contact Availability at the database-level.
+'''
 
 from enum import Enum, auto
 

--- a/star_tides/services/databases/mongo/models/availability_test.py
+++ b/star_tides/services/databases/mongo/models/availability_test.py
@@ -1,0 +1,8 @@
+'''Tests for objects in the availability.py file.'''
+
+from .availability import Availability
+
+def test_all_values_present():
+    got = {e.name for e in list(Availability)}
+    want = {'UNSPECIFIED', 'UNAVAILABLE', 'AVAILABLE'}
+    assert got == want

--- a/star_tides/services/databases/mongo/models/availability_test.py
+++ b/star_tides/services/databases/mongo/models/availability_test.py
@@ -1,8 +1,0 @@
-'''Tests for objects in the availability.py file.'''
-
-from .availability import Availability
-
-def test_all_values_present():
-    got = {e.name for e in list(Availability)}
-    want = {'UNSPECIFIED', 'UNAVAILABLE', 'AVAILABLE'}
-    assert got == want

--- a/star_tides/services/databases/mongo/models/contact_model.py
+++ b/star_tides/services/databases/mongo/models/contact_model.py
@@ -1,10 +1,14 @@
-'''ContactModel representing Contact objects in the MongoDB database.'''
+'''
+star_tides.services.databases.mongo.models.contact_model
+
+ContactModel representing Contact objects in the MongoDB database.
+'''
 
 from mongoengine import Document, StringField, EmailField, UUIDField, URLField
 from mongoengine.fields import EmbeddedDocumentField, ListField, EnumField
-from .location_model import LocationModel
-from .engagement_model import EngagementModel
-from .availability import Availability
+from star_tides.services.databases.mongo.models.location_model import LocationModel
+from star_tides.services.databases.mongo.models.engagement_model import EngagementModel
+from star_tides.services.databases.mongo.models.availability import Availability
 
 class ContactModel(Document):
     '''Contact MongoDB model.'''

--- a/star_tides/services/databases/mongo/models/contact_model.py
+++ b/star_tides/services/databases/mongo/models/contact_model.py
@@ -1,0 +1,29 @@
+'''ContactModel representing Contact objects in the MongoDB database.'''
+
+from mongoengine import Document, StringField, EmailField, UUIDField, URLField
+from mongoengine.fields import EmbeddedDocumentField, ListField, EnumField
+from .location_model import LocationModel
+from .engagement_model import EngagementModel
+from .availability import Availability
+
+class ContactModel(Document):
+    '''Contact MongoDB model.'''
+
+    user_id = UUIDField(binary=False, required=False)
+    name = StringField(required=True)
+    email = EmailField(required=False)
+    phone_number = StringField(required=False)
+    job_title = StringField(required=False)
+    website_url = URLField(required=False)
+    location = EmbeddedDocumentField(LocationModel, required=True)
+    languages = ListField(required=False)
+    availability = EnumField(Availability, required=True)
+    engagement = EmbeddedDocumentField(EngagementModel, required=True)
+    statuses = ListField(required=False)
+
+    # Append-only list of (user_id, timestamp) objects for edits on this
+    # ContactModel object. The first item is the creation of this model.
+    update_timestamps = ListField(required=True)
+
+    # NOTE: Projects will link to this contact object,
+    # not the other way around.

--- a/star_tides/services/databases/mongo/models/engagement_model.py
+++ b/star_tides/services/databases/mongo/models/engagement_model.py
@@ -1,10 +1,13 @@
-'''Objects and utilities for working with "engagement" data (e.g. what areas of
+'''
+star_tides.services.databases.mongo.models.engagement_model
+
+Objects and utilities for working with "engagement" data (e.g. what areas of
 interest a contact is interested in) at the database level.
 '''
 
 from mongoengine import EmbeddedDocument
 from mongoengine.fields import EmbeddedDocumentListField, ListField
-from .location_model import LocationModel
+from star_tides.services.databases.mongo.models.location_model import LocationModel
 
 class EngagementModel(EmbeddedDocument):
     '''

--- a/star_tides/services/databases/mongo/models/engagement_model.py
+++ b/star_tides/services/databases/mongo/models/engagement_model.py
@@ -1,0 +1,19 @@
+'''Objects and utilities for working with "engagement" data (e.g. what areas of
+interest a contact is interested in) at the database level.
+'''
+
+from mongoengine import EmbeddedDocument
+from mongoengine.fields import EmbeddedDocumentListField, ListField
+from .location_model import LocationModel
+
+class EngagementModel(EmbeddedDocument):
+    '''
+    Engagement model for attaching engagement information to a model via a
+    mongoengine.EmbeddedDocumentfield.
+    '''
+
+    locations = EmbeddedDocumentListField(LocationModel, required=True)
+    backgrounds = ListField(required=True)
+    areas_of_interest = ListField(required=True)
+    focuses = ListField(required=True)
+

--- a/star_tides/services/databases/mongo/models/location_model.py
+++ b/star_tides/services/databases/mongo/models/location_model.py
@@ -1,0 +1,13 @@
+'''Objects and utilities for working with geographic locations at the database
+level.
+'''
+
+from mongoengine import EmbeddedDocument, IntField, StringField
+
+class LocationModel(EmbeddedDocument):
+    '''Location model for attaching geographic information to a model via a
+    mongoengine.EmbeddedDocumentField.
+    '''
+
+    iso_3166_1_country_code = IntField(required=True)
+    arbitrary_text = StringField(required=False)

--- a/star_tides/services/databases/mongo/models/location_model.py
+++ b/star_tides/services/databases/mongo/models/location_model.py
@@ -1,4 +1,7 @@
-'''Objects and utilities for working with geographic locations at the database
+'''
+star_tides.services.databases.mongo.models.location_model
+
+Objects and utilities for working with geographic locations at the database
 level.
 '''
 

--- a/star_tides/services/databases/mongo/models/test_availability.py
+++ b/star_tides/services/databases/mongo/models/test_availability.py
@@ -1,0 +1,12 @@
+'''
+star_tides.services.databases.mongo.models.availability_test
+
+Tests for objects in the availability.py file.
+'''
+
+from star_tides.services.databases.mongo.models.availability import Availability
+
+def test_all_values_present():
+    got = {e.name for e in list(Availability)}
+    want = {'UNSPECIFIED', 'UNAVAILABLE', 'AVAILABLE'}
+    assert got == want


### PR DESCRIPTION
This should close #10 .

Note that I added a few `EmbeddedDocument`s, which don't exist as their own collections but are embedded in larger objects. This will allow us to better share code between our top-level DB objects, like Projects and Contacts.

LMK if you want me to add more tests, especially on the models themselves (e.g. field presence etc.).

I can also add validation for things, like checking ISO country codes, timestamps etc.